### PR TITLE
Fix image paths and config typo for Hugo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@ baseURL = "https://itj-labs.github.io/department-site/"
 languageCode = "en-us"
 title = "ITJ Labs Department"
 theme = "PaperMod"
-realtiveURLs = true
+relativeURLs = true
 
 [params]
   primaryHue       = 220

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -12,7 +12,7 @@ draft       = false
 <div class="mission-vision">
   <div class="mv-cards">
     <div class="mv-card">
-      <img src="images/icons/mission.svg" alt="" class="mv-icon" />
+      <img src="/images/icons/mission.svg" alt="" class="mv-icon" />
       <h2>Our Mission</h2>
       <p>
         At ITJ Labs Department, our mission is to empower organizations with
@@ -21,7 +21,7 @@ draft       = false
       </p>
     </div>
     <div class="mv-card">
-      <img src="images/icons/vision.svg" alt="" class="mv-icon" />
+      <img src="/images/icons/vision.svg" alt="" class="mv-icon" />
       <h2>Our Vision</h2>
       <p>
         We envision a world where cutting-edge AI solutions are accessible to
@@ -45,7 +45,7 @@ draft       = false
     <div class="flip-card-inner">
       <div class="flip-card-front">
         <h3>Build capabilities around AI and related technologies</h3>
-        <img class="goal-icon" src="images/icons/ai-capabilities.svg" alt="AI Capabilities">
+        <img class="goal-icon" src="/images/icons/ai-capabilities.svg" alt="AI Capabilities">
       </div>
       <div class="flip-card-back">
         <p>We act as a liaison and consulting group within ITJ to support localized AI initiatives across the organization.</p>
@@ -58,7 +58,7 @@ draft       = false
     <div class="flip-card-inner">
       <div class="flip-card-front">
         <h3>Design, build and implement AI products and services</h3>
-        <img class="goal-icon" src="images/icons/ai-products.svg" alt="AI Products">
+        <img class="goal-icon" src="/images/icons/ai-products.svg" alt="AI Products">
       </div>
       <div class="flip-card-back">
         <p>We create production-ready AI solutions—not just for ITJ’s core business, but also by leveraging public data to spark new innovations.</p>
@@ -71,7 +71,7 @@ draft       = false
     <div class="flip-card-inner">
       <div class="flip-card-front">
         <h3>Divulge AI knowledge and information</h3>
-        <img class="goal-icon" src="images/icons/ai-knowledge.svg" alt="AI Knowledge">
+        <img class="goal-icon" src="/images/icons/ai-knowledge.svg" alt="AI Knowledge">
       </div>
       <div class="flip-card-back">
         <p>In partnership with prestigious universities, we serve as a central knowledge hub for AI research and insights.</p>
@@ -91,22 +91,22 @@ We collaborate with top institutions, research centers, and clients to drive AI 
 <div class="partners-grid">
   <div class="partner-logo" data-aos="fade-up">
     <a href="https://www.citedi.mx/portal/" target="_blank" rel="noopener">
-      <img src="images/partners/citedi.png" alt="CITEDI-IPN">
+      <img src="/images/partners/citedi.png" alt="CITEDI-IPN">
     </a>
   </div>
   <div class="partner-logo" data-aos="fade-up" data-aos-delay="100">
     <a href="https://www.cetys.mx/" target="_blank" rel="noopener">
-      <img src="images/partners/cetys.png" alt="CETYS">
+      <img src="/images/partners/cetys.png" alt="CETYS">
     </a>
   </div>
   <div class="partner-logo" data-aos="fade-up" data-aos-delay="200">
     <a href="https://www.uabc.mx/" target="_blank" rel="noopener">
-      <img src="images/partners/uabc.png" alt="UABC">
+      <img src="/images/partners/uabc.png" alt="UABC">
     </a>
   </div>
   <div class="partner-logo" data-aos="fade-up" data-aos-delay="300">
     <a href="https://www.tijuana.tecnm.mx/" target="_blank" rel="noopener">
-      <img src="images/partners/itt.png" alt="ITT-TecNM">
+      <img src="/images/partners/itt.png" alt="ITT-TecNM">
     </a>
   </div>
 </div>
@@ -116,7 +116,7 @@ We collaborate with top institutions, research centers, and clients to drive AI 
 
 <section class="team-leaders two-per-row">
     <div class="leader-card">
-  <img src="images/team/phil.png" alt="Phil Sweeney" />
+  <img src="/images/team/phil.png" alt="Phil Sweeney" />
   <h3>Phil Sweeney</h3>
   <p class="role">Principal Business Leader</p>
   <blockquote>
@@ -129,12 +129,12 @@ We collaborate with top institutions, research centers, and clients to drive AI 
   </ul>
   <div class="social-links">
     <a href="https://www.linkedin.com/in/phillipsweeney/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer">
-      <img src="images/icons/linkedin.svg" alt="LinkedIn" />
+      <img src="/images/icons/linkedin.svg" alt="LinkedIn" />
     </a>
   </div>
 </div>
     <div class="leader-card">
-      <img src="images/team/rafa.png" alt="Rafael GPL" />
+      <img src="/images/team/rafa.png" alt="Rafael GPL" />
       <h3>Rafael GPL</h3>
       <p class="role">Data Science Director</p>
       <blockquote>
@@ -147,12 +147,12 @@ We collaborate with top institutions, research centers, and clients to drive AI 
       </ul>
       <div class="social-links">
         <a href="https://www.linkedin.com/in/rafaelgpl/" aria-label="LinkedIn" target="_blank" re="noopener noreferrer">
-          <img src="images/icons/linkedin.svg" alt="LinkedIn" />
+          <img src="/images/icons/linkedin.svg" alt="LinkedIn" />
         </a>
       </div>
     </div>
 <div class="leader-card">
-  <img src="images/team/drmike.png" alt="Dr. Miguel López" />
+  <img src="/images/team/drmike.png" alt="Dr. Miguel López" />
   <h3>Dr. Miguel López</h3>
   <p class="role">Data Science Manager</p>
   <blockquote>
@@ -165,21 +165,21 @@ We collaborate with top institutions, research centers, and clients to drive AI 
   </ul>
   <div class="social-links">
     <a href="https://orcid.org/0000-0001-5367-9801" aria-label="ORCID" target="_blank" rel="noopener noreferrer">
-      <img src="images/icons/orcid.svg" alt="ORCID" />
+      <img src="/images/icons/orcid.svg" alt="ORCID" />
     </a>
     <a href="https://www.linkedin.com/in/miguel-angel-lopez-montiel/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer">
-      <img src="images/icons/linkedin.svg" alt="LinkedIn" />
+      <img src="/images/icons/linkedin.svg" alt="LinkedIn" />
     </a>
     <a href="https://scholar.google.com/citations?user=ejQAKasAAAAJ&hl=en" aria-label="Google Scholar" target="_blank" rel="noopener noreferrer">
-      <img src="images/icons/google-scholar.svg" alt="Google Scholar" />
+      <img src="/images/icons/google-scholar.svg" alt="Google Scholar" />
     </a>
     <a href="https://www.scopus.com/authid/detail.uri?authorId=57212031562" aria-label="Scopus" target="_blank" rel="noopener noreferrer">
-      <img src="images/icons/scopus.svg" alt="Scopus" />
+      <img src="/images/icons/scopus.svg" alt="Scopus" />
     </a>
   </div>
 </div>
 <div class="leader-card">
-  <img src="images/team/ivan.png" alt="Ivan Romero" />
+  <img src="/images/team/ivan.png" alt="Ivan Romero" />
   <h3>Ivan Romero</h3>
   <p class="role">Project Manager</p>
   <blockquote>
@@ -192,7 +192,7 @@ We collaborate with top institutions, research centers, and clients to drive AI 
   </ul>
   <div class="social-links">
     <a href="https://www.linkedin.com/in/ivanrromero/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer">
-      <img src="images/icons/linkedin.svg" alt="LinkedIn" />
+      <img src="/images/icons/linkedin.svg" alt="LinkedIn" />
     </a>
   </div>
 </div>

--- a/content/events/2024-cetys-lobby-empresarial.md
+++ b/content/events/2024-cetys-lobby-empresarial.md
@@ -5,9 +5,9 @@ location = "CETYS Universidad, Tijuana Campus"
 type = "Panel"
 tags = ["ai", "cybersecurity", "industry", "strategy"]
 images = [
-    "images/events/2024/lobby-empresarial/lobby-1.jpg",
-    "images/events/2024/lobby-empresarial/lobby-2.jpg",
-    "images/events/2024/lobby-empresarial/lobby-3.jpg"
+    "/images/events/2024/lobby-empresarial/lobby-1.jpg",
+    "/images/events/2024/lobby-empresarial/lobby-2.jpg",
+    "/images/events/2024/lobby-empresarial/lobby-3.jpg"
 ]
 summary = "Our team was represented at CETYS Universidad’s Lobby Empresarial panel on Cybersecurity and AI, where experts from academia and industry discussed current challenges and opportunities in the digital transformation of enterprises."
 draft = false

--- a/content/events/2024-citedi-quantum-ai.md
+++ b/content/events/2024-citedi-quantum-ai.md
@@ -5,15 +5,15 @@ location = "CITEDI-IPN, Tijuana / Online"
 type = "Seminar"
 tags = ["quantum computing", "AI", "seminar"]
 images = [
-  "images/events/2024/citedi-october/citedi-1.jpg",
-  "images/events/2024/citedi-october/citedi-2.jpg",
-  "images/events/2024/citedi-october/citedi-3.jpg",
-  "images/events/2024/citedi-october/citedi-4.jpg",
-  "images/events/2024/citedi-october/citedi-5.jpg",
-  "images/events/2024/citedi-october/citedi-6.jpg",
-  "images/events/2024/citedi-october/citedi-7.jpg",
-  "images/events/2024/citedi-october/citedi-8.jpg",
-  "images/events/2024/citedi-october/citedi-9.jpg"
+  "/images/events/2024/citedi-october/citedi-1.jpg",
+  "/images/events/2024/citedi-october/citedi-2.jpg",
+  "/images/events/2024/citedi-october/citedi-3.jpg",
+  "/images/events/2024/citedi-october/citedi-4.jpg",
+  "/images/events/2024/citedi-october/citedi-5.jpg",
+  "/images/events/2024/citedi-october/citedi-6.jpg",
+  "/images/events/2024/citedi-october/citedi-7.jpg",
+  "/images/events/2024/citedi-october/citedi-8.jpg",
+  "/images/events/2024/citedi-october/citedi-9.jpg"
 ]
 summary = "We participated as guest speakers in CITEDI-IPN’s Seminar on Artificial Intelligence and Quantum Computing, sharing insights on real-world AI research, QML, and emerging applications."
 draft = false

--- a/content/events/2024-conisoft-cnn-workshop.md
+++ b/content/events/2024-conisoft-cnn-workshop.md
@@ -4,7 +4,7 @@ date = 2024-10-30T11:00:00-06:00
 location = "Universidad del Mar, Puerto Escondido, Oaxaca, México"
 type = "Workshop"
 tags = ["cnn", "pytorch", "image classification", "conference"]
-image = "images/events/2024/conisoft-cnn-workshop/conisoft-1.png"
+image = "/images/events/2024/conisoft-cnn-workshop/conisoft-1.png"
 summary = "Hands-on workshop at CONISOFT 2024 covering CNN fundamentals, model building with PyTorch, and transfer learning techniques using MobileNet and ResNet for efficient image classification."
 draft = false
 +++

--- a/content/events/2024-micoach-pytorch-bootcamp.md
+++ b/content/events/2024-micoach-pytorch-bootcamp.md
@@ -4,7 +4,7 @@ date = 2024-11-19T20:00:00-07:00
 location = "Online / miCoach"
 type = "Bootcamp"
 tags = ["deep learning", "pytorch", "bootcamp"]
-image = "images/events/2024/micoach-bootcamp-pytorch/micoach-1.jpg"
+image = "/images/events/2024/micoach-bootcamp-pytorch/micoach-1.jpg"
 summary = "In this practical bootcamp, we guided participants through the foundations of deep learning using PyTorch — covering tensors, training loops, model design, and real-world applications."
 draft = false
 +++

--- a/content/events/2024-micoach-talk-deep-learning.md
+++ b/content/events/2024-micoach-talk-deep-learning.md
@@ -4,7 +4,7 @@ date = 2024-09-05T17:00:00-07:00
 location = "Online / miCoach"
 type = "Tech Talk"
 tags = ["deep learning", "training", "community"]
-image = "images/events/2024/micoach-talk-deep-learning/micoach-1.jpg"
+image = "/images/events/2024/micoach-talk-deep-learning/micoach-1.jpg"
 summary = "We hosted a technical session for the miCoach community, explaining how deep learning models work under the hood — from linear algebra intuition to CNNs and Transformers."
 draft = false
 +++

--- a/content/events/2024-neo-vit-presentation.md
+++ b/content/events/2024-neo-vit-presentation.md
@@ -4,7 +4,7 @@ date = 2024-10-28
 location = "Puerto Vallarta, Jalisco, México"
 type = "Conference Presentation"
 tags = ["vision transformers", "industrial AI", "welding", "neo"]
-image = "images/events/2024/neo/visual-abstract.png"
+image = "/images/events/2024/neo/visual-abstract.png"
 summary = "We presented our research on Vision Transformers for industrial defect detection at NEO 2024, highlighting multiclass classification accuracy and its application to quality control in manufacturing."
 draft = false
 +++

--- a/content/events/2024-uabc.md
+++ b/content/events/2024-uabc.md
@@ -5,16 +5,16 @@ location = "UABC – Faculty of Accounting and Administration, Tijuana"
 type = "Conference"
 tags = ["academic", "business intelligence", "university"]
 images =[
-    "images/events/2024/uabc-november/uabc-1.jpg",
-    "images/events/2024/uabc-november/uabc-2.jpg",
-    "images/events/2024/uabc-november/uabc-3.jpg",
-    "images/events/2024/uabc-november/uabc-4.jpg",
-    "images/events/2024/uabc-november/uabc-5.jpg",
-    "images/events/2024/uabc-november/uabc-6.jpg",
-    "images/events/2024/uabc-november/uabc-7.jpg",
-    "images/events/2024/uabc-november/uabc-8.jpg",
-    "images/events/2024/uabc-november/uabc-9.jpg",
-    "images/events/2024/uabc-november/uabc-10.jpg"
+    "/images/events/2024/uabc-november/uabc-1.jpg",
+    "/images/events/2024/uabc-november/uabc-2.jpg",
+    "/images/events/2024/uabc-november/uabc-3.jpg",
+    "/images/events/2024/uabc-november/uabc-4.jpg",
+    "/images/events/2024/uabc-november/uabc-5.jpg",
+    "/images/events/2024/uabc-november/uabc-6.jpg",
+    "/images/events/2024/uabc-november/uabc-7.jpg",
+    "/images/events/2024/uabc-november/uabc-8.jpg",
+    "/images/events/2024/uabc-november/uabc-9.jpg",
+    "/images/events/2024/uabc-november/uabc-10.jpg"
 ]
 summary = "Invited talk as part of the Business Intelligence Conference Series organized by UABC, promoting student engagement in professional development."
 draft = false

--- a/content/events/2025-foro-mujer-actual.md
+++ b/content/events/2025-foro-mujer-actual.md
@@ -4,7 +4,7 @@ date = 2025-03-04T10:20:00-08:00
 location = "Vía Corporativo, Tijuana"
 type = "Panel"
 tags = ["innovation", "women in tech", "community"]
-image = "images/events/2025/foro-mujer-actual/kath-1.png"
+image = "/images/events/2025/foro-mujer-actual/kath-1.png"
 summary = "Our team was represented in the 15th Foro Mujer Actual, participating in the Innovation Panel with other women leaders in celebration of International Women's Day and the magazine’s 18th anniversary."
 draft = false
 +++

--- a/content/events/2025-micoach-cnn-pytorch-bootcamp.md
+++ b/content/events/2025-micoach-cnn-pytorch-bootcamp.md
@@ -4,7 +4,7 @@ date = 2025-03-05T17:00:00-08:00
 location = "Online / miCoach"
 type = "Bootcamp"
 tags = ["cnn", "pytorch", "image classification", "training"]
-image = "images/events/2025/micoach-cnn-bootcamp/cnn-1.jpeg"
+image = "/images/events/2025/micoach-cnn-bootcamp/cnn-1.jpeg"
 summary = "We led a practical bootcamp with miCoach on building and training convolutional neural networks (CNNs) using PyTorch. Participants gained hands-on experience creating custom models for image classification, and explored transfer learning techniques."
 draft = false
 +++

--- a/content/events/2025-micoach-transformers-tech-talk.md
+++ b/content/events/2025-micoach-transformers-tech-talk.md
@@ -4,7 +4,7 @@ date = 2025-04-24T17:00:00-08:00
 location = "Online / miCoach"
 type = "Tech Talk"
 tags = ["transformers", "nlp", "deep learning", "llm"]
-image = "images/events/2025/micoach-transformers-talk/transformers-1.png"
+image = "/images/events/2025/micoach-transformers-talk/transformers-1.png"
 summary = "In this Tech Talk hosted by miCoach, we explored the foundation of transformer-based architectures such as BERT and GPT, including self-attention mechanisms, token embeddings, and how they enable breakthroughs in language modeling and beyond."
 draft = false
 +++

--- a/content/events/2025-micoach-transformers-workshop.md
+++ b/content/events/2025-micoach-transformers-workshop.md
@@ -4,7 +4,7 @@ date = 2025-05-28T17:00:00-08:00
 location = "Online / miCoach"
 type = "Workshop"
 tags = ["transformers", "hugging face", "langchain", "llm", "prompt engineering"]
-image = "images/events/2025/micoach-transformers-workshop/hf-1.jpeg"
+image = "/images/events/2025/micoach-transformers-workshop/hf-1.jpeg"
 summary = "This advanced hands-on workshop guided participants through mastering Transformers using Hugging Face and LangChain. The session covered prompt templates, chaining logic, inference workflows, and real-world deployment considerations for LLM-based applications."
 draft = false
 +++


### PR DESCRIPTION
## Summary
- correct typo in `config.toml`
- update all image references in the about page to use absolute `/images/` paths
- fix event front-matter to use `/images/...` paths

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684252630ae0832d87ecc4cdf2de55c2