### PR TITLE
Fix GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,11 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.147.6'
+
+      - name: Install PaperMod theme
+        run: |
+          git clone --depth 1 https://github.com/adityatelange/hugo-PaperMod themes/PaperMod
 
       - name: Build site
         run: hugo --minify --baseURL=https://itj-labs.github.io/department-site/


### PR DESCRIPTION
## Summary
- deploy workflow triggers on `develop` branch
- pin Hugo version to `0.147.6`
- clone PaperMod theme before build

## Testing
- `./scripts/test-deploy.sh` *(fails: `hugo` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684257efc78c832db1f725b299017f4f