### PR TITLE
Add PaperMod submodule and update docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,8 @@ jobs:
         with:
           hugo-version: '0.147.6'
 
-      - name: Install PaperMod theme
-        run: |
-          git clone --depth 1 https://github.com/adityatelange/hugo-PaperMod themes/PaperMod
+      - name: Fetch submodules
+        run: git submodule update --init --recursive
 
       - name: Build site
         run: hugo --minify --baseURL=https://itj-labs.github.io/department-site/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "themes/PaperMod"]
+	path = themes/PaperMod
+	url = https://github.com/adityatelange/hugo-PaperMod.git

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # department-site
+
 ITJ Labs Department website
+
+## Theme Setup
+
+This site uses the [PaperMod](https://github.com/adityatelange/hugo-PaperMod) theme as a git submodule. After cloning the repository, run the following to fetch the theme files:
+
+```bash
+git submodule update --init --recursive
+```
+
+If you cloned with `--recursive`, the theme will already be present under `themes/PaperMod`.


### PR DESCRIPTION
## Summary
- add PaperMod theme as a git submodule
- update the GitHub Actions workflow to fetch submodules
- document the theme setup in README

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_68426537ea08832d8368a7149ed04b53