### PR TITLE
Fix: Event Page Images

### DIFF
--- a/content/events/2024-cetys-lobby-empresarial.md
+++ b/content/events/2024-cetys-lobby-empresarial.md
@@ -5,9 +5,9 @@ location = "CETYS Universidad, Tijuana Campus"
 type = "Panel"
 tags = ["ai", "cybersecurity", "industry", "strategy"]
 images = [
-    "images/events/2024/lobby-empresarial/lobby-1.jpg",
-    "images/events/2024/lobby-empresarial/lobby-2.jpg",
-    "images/events/2024/lobby-empresarial/lobby-3.jpg"
+    "/images/events/2024/lobby-empresarial/lobby-1.jpg",
+    "/images/events/2024/lobby-empresarial/lobby-2.jpg",
+    "/images/events/2024/lobby-empresarial/lobby-3.jpg"
 ]
 summary = "Our team was represented at CETYS Universidad’s Lobby Empresarial panel on Cybersecurity and AI, where experts from academia and industry discussed current challenges and opportunities in the digital transformation of enterprises."
 draft = false

--- a/content/events/2024-citedi-quantum-ai.md
+++ b/content/events/2024-citedi-quantum-ai.md
@@ -5,15 +5,15 @@ location = "CITEDI-IPN, Tijuana / Online"
 type = "Seminar"
 tags = ["quantum computing", "AI", "seminar"]
 images = [
-  "images/events/2024/citedi-october/citedi-1.jpg",
-  "images/events/2024/citedi-october/citedi-2.jpg",
-  "images/events/2024/citedi-october/citedi-3.jpg",
-  "images/events/2024/citedi-october/citedi-4.jpg",
-  "images/events/2024/citedi-october/citedi-5.jpg",
-  "images/events/2024/citedi-october/citedi-6.jpg",
-  "images/events/2024/citedi-october/citedi-7.jpg",
-  "images/events/2024/citedi-october/citedi-8.jpg",
-  "images/events/2024/citedi-october/citedi-9.jpg"
+  "/images/events/2024/citedi-october/citedi-1.jpg",
+  "/images/events/2024/citedi-october/citedi-2.jpg",
+  "/images/events/2024/citedi-october/citedi-3.jpg",
+  "/images/events/2024/citedi-october/citedi-4.jpg",
+  "/images/events/2024/citedi-october/citedi-5.jpg",
+  "/images/events/2024/citedi-october/citedi-6.jpg",
+  "/images/events/2024/citedi-october/citedi-7.jpg",
+  "/images/events/2024/citedi-october/citedi-8.jpg",
+  "/images/events/2024/citedi-october/citedi-9.jpg"
 ]
 summary = "We participated as guest speakers in CITEDI-IPN’s Seminar on Artificial Intelligence and Quantum Computing, sharing insights on real-world AI research, QML, and emerging applications."
 draft = false

--- a/content/events/2024-uabc.md
+++ b/content/events/2024-uabc.md
@@ -5,16 +5,16 @@ location = "UABC – Faculty of Accounting and Administration, Tijuana"
 type = "Conference"
 tags = ["academic", "business intelligence", "university"]
 images =[
-    "images/events/2024/uabc-november/uabc-1.jpg",
-    "images/events/2024/uabc-november/uabc-2.jpg",
-    "images/events/2024/uabc-november/uabc-3.jpg",
-    "images/events/2024/uabc-november/uabc-4.jpg",
-    "images/events/2024/uabc-november/uabc-5.jpg",
-    "images/events/2024/uabc-november/uabc-6.jpg",
-    "images/events/2024/uabc-november/uabc-7.jpg",
-    "images/events/2024/uabc-november/uabc-8.jpg",
-    "images/events/2024/uabc-november/uabc-9.jpg",
-    "images/events/2024/uabc-november/uabc-10.jpg"
+    "/images/events/2024/uabc-november/uabc-1.jpg",
+    "/images/events/2024/uabc-november/uabc-2.jpg",
+    "/images/events/2024/uabc-november/uabc-3.jpg",
+    "/images/events/2024/uabc-november/uabc-4.jpg",
+    "/images/events/2024/uabc-november/uabc-5.jpg",
+    "/images/events/2024/uabc-november/uabc-6.jpg",
+    "/images/events/2024/uabc-november/uabc-7.jpg",
+    "/images/events/2024/uabc-november/uabc-8.jpg",
+    "/images/events/2024/uabc-november/uabc-9.jpg",
+    "/images/events/2024/uabc-november/uabc-10.jpg"
 ]
 summary = "Invited talk as part of the Business Intelligence Conference Series organized by UABC, promoting student engagement in professional development."
 draft = false

--- a/layouts/events/list.html
+++ b/layouts/events/list.html
@@ -15,7 +15,7 @@
 
         {{ if $imgs }}
           <div class="event-image-slideshow" data-images='{{ jsonify $imgs }}'>
-            <img class="event-image-slide" alt="{{ $.Title }}">
+		<img class="event-image-slide" src="{{ index $imgs 0 }}" alt="{{ $.Title }}">
           </div>
         {{ end }}
 


### PR DESCRIPTION
This PR fixes the event card images on /events/ by:
- Updating image paths in event front matter to use absolute URLs
- Binding image src correctly in list.html layout